### PR TITLE
Update workflow to use repo variable

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,38 +1,55 @@
+---
 name: Build and Push Docker image
 
-on:
+"on":
   push:
-    branches: [ "main" ]
-    tags: [ "*" ]
+    branches: ["main"]
   workflow_dispatch:
 
 jobs:
-  build-and-push:
+  build-and-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
-    - name: Extract branch name or tag
-      id: ref
-      run: |
-        if [[ $GITHUB_REF == refs/tags/* ]]; then
-          echo "::set-output name=tag::$(echo $GITHUB_REF | sed 's|refs/tags/||')"
-        elif [[ $GITHUB_REF == refs/heads/* ]]; then
-          echo "::set-output name=tag::$(echo $GITHUB_REF | sed 's|refs/heads/||')"
-        fi
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v6
-      with:
-        context: ./docker
-        file: ./docker/Dockerfile.prod
-        platforms: linux/amd64
-        push: true
-        tags: |
-          mizucopo/rtsp2storage:${{ steps.ref.outputs.tag == 'main' && 'latest' || steps.ref.outputs.tag }}
+      - name: 読み込んだバージョンを取得
+        id: vars
+        run: echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+
+      - name: リポジトリ名を取得
+        id: repo
+        run: |
+          repo=$(basename "$GITHUB_REPOSITORY")
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "image=mizucopo/$repo" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile.prod
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.repo.outputs.image }}:latest
+            ${{ steps.repo.outputs.image }}:${{ steps.vars.outputs.version }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.vars.outputs.version }}
+          target_commitish: main
+          name: Release ${{ steps.vars.outputs.version }}
+          body: |
+            VERSION: ${{ steps.vars.outputs.version }}
+            Docker image:
+              ${{ steps.repo.outputs.image }}:${{ steps.vars.outputs.version }}


### PR DESCRIPTION
## Summary
- set repo name and image variables in workflow
- use variables when tagging Docker images and release body

## Testing
- `yamllint .github/workflows/docker-build.yml`
- `shellcheck docker/ffmpeg.sh` *(shows style warnings)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684314a637b0832c9a5677aa83ffa831